### PR TITLE
Fixed error when updating user

### DIFF
--- a/app/Http/Controllers/UsersManagementController.php
+++ b/app/Http/Controllers/UsersManagementController.php
@@ -177,7 +177,7 @@ class UsersManagementController extends Controller
             ]);
         } else {
             $validator = Validator::make($request->all(), [
-                'name'     => 'required|max:255|unique:users',
+                'name'     => 'required|max:255',
                 'password' => 'nullable|confirmed|min:6',
             ]);
         }


### PR DESCRIPTION
Fixed error when updating user from Admin to user or unverified it would state "That username is already taken". This patches it.